### PR TITLE
Improve security of the generator

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -11,17 +11,28 @@ const CHARACTERS = "0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
   };
 })();
 
+function uniformGen(range) {
+  let max = Math.floor(2**32 / range) * range;
+  let x = max;
+
+  do {
+    x = Math.floor(Math.random() * 2**32);
+  } while (x >= max);
+
+  return (x % range);
+}
+
 function maybePush(myArray) {
-  let char = CHARACTERS[Math.floor(Math.random() * CHARACTERS.length)];
-  if (Math.random() > 0.5) {
+  let char = CHARACTERS[uniformGen(CHARACTERS.length)];
+  if (Math.random() >= 0.5) {
     return myArray.push(char)
   }
 }
 
 $.getJSON("/wordlist.json", function(wordlist) {
   let password = [];
-  for (var i = 0; i < 3; i++) {
-    let word = wordlist['words'][Math.floor(Math.random() * wordlist['words'].length)];
+  for (var i = 0; i < 4; i++) {
+    let word = wordlist['words'][uniformGen(wordlist['words'].length)];
     password.push(word.charAt(0).toUpperCase() + word.slice(1));
     maybePush(password);
   }


### PR DESCRIPTION
* Increase the default word count from 3 to 4
  - Bumps the base security margin from 50 bits to 67 bits
* Fix logic bug with maybePush()
  - Range is [0, 1), so 0.5 is the midpoint.
* Replace biased generator with a uniform generator
  - Multiply-and-floor is only uniform if the domain is a power of 2
  - Replaced with modulo-with-rejection